### PR TITLE
chore: update Go version for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22-alpine AS build
+FROM golang:1.24-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- build Docker image with Go 1.24

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d22e44a288325acbd90237d340e87