### PR TITLE
Improve variable naming for clarity

### DIFF
--- a/internal/application/useCase/category.go
+++ b/internal/application/useCase/category.go
@@ -15,19 +15,19 @@ func NewCategoryService(repo interfaces.CategoryRepository) *CategoryService {
 	return &CategoryService{repo: repo}
 }
 
-func (s *CategoryService) Create(ctx context.Context, c *entities.Category) error {
-	if err := validations.ValidateNewCategory(c); err != nil {
+func (s *CategoryService) Create(ctx context.Context, category *entities.Category) error {
+	if err := validations.ValidateNewCategory(category); err != nil {
 		return err
 	}
 
-	return s.repo.Create(ctx, c)
+	return s.repo.Create(ctx, category)
 }
 
-func (s *CategoryService) Update(ctx context.Context, c *entities.Category) error {
-	if err := validations.ValidateUpdate(c); err != nil {
+func (s *CategoryService) Update(ctx context.Context, category *entities.Category) error {
+	if err := validations.ValidateUpdate(category); err != nil {
 		return err
 	}
-	return s.repo.Update(ctx, c)
+	return s.repo.Update(ctx, category)
 }
 
 func (s *CategoryService) Delete(ctx context.Context, id uint, userID uint) error {

--- a/internal/application/useCase/task.go
+++ b/internal/application/useCase/task.go
@@ -21,20 +21,20 @@ func NewTaskService(repo interfaces.TaskRepository) *TaskService {
 	return &TaskService{repo: repo}
 }
 
-func (s *TaskService) Create(ctx context.Context, t *entities.Task) error {
-	if t.State == "" {
-		t.State = "Sin Empezar"
-	} else if !allowedStates[t.State] {
+func (s *TaskService) Create(ctx context.Context, task *entities.Task) error {
+	if task.State == "" {
+		task.State = "Sin Empezar"
+	} else if !allowedStates[task.State] {
 		return errors.New("invalid state")
 	}
-	return s.repo.Create(ctx, t)
+	return s.repo.Create(ctx, task)
 }
 
-func (s *TaskService) Update(ctx context.Context, t *entities.Task) error {
-	if t.State != "" && !allowedStates[t.State] {
+func (s *TaskService) Update(ctx context.Context, task *entities.Task) error {
+	if task.State != "" && !allowedStates[task.State] {
 		return errors.New("invalid state")
 	}
-	return s.repo.Update(ctx, t)
+	return s.repo.Update(ctx, task)
 }
 
 func (s *TaskService) Delete(ctx context.Context, id uint, userID uint) error {
@@ -45,6 +45,6 @@ func (s *TaskService) Get(ctx context.Context, id uint, userID uint) (*entities.
 	return s.repo.Get(ctx, id, userID)
 }
 
-func (s *TaskService) List(ctx context.Context, userID uint, f interfaces.TaskFilter) ([]entities.Task, error) {
-	return s.repo.List(ctx, userID, f)
+func (s *TaskService) List(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, error) {
+	return s.repo.List(ctx, userID, filter)
 }

--- a/internal/domain/interfaces/category_repository.go
+++ b/internal/domain/interfaces/category_repository.go
@@ -8,8 +8,8 @@ import (
 // CategoryRepository defines the persistence behavior required by the
 // application layer. Implementations live in the infrastructure package.
 type CategoryRepository interface {
-	Create(ctx context.Context, c *entities.Category) error
-	Update(ctx context.Context, c *entities.Category) error
+	Create(ctx context.Context, category *entities.Category) error
+	Update(ctx context.Context, category *entities.Category) error
 	Delete(ctx context.Context, id uint, userID uint) error
 	Get(ctx context.Context, id uint, userID uint) (*entities.Category, error)
 	List(ctx context.Context, userID uint) ([]entities.Category, error)

--- a/internal/domain/interfaces/task_repository.go
+++ b/internal/domain/interfaces/task_repository.go
@@ -12,9 +12,9 @@ type TaskFilter struct {
 
 // TaskRepository defines the persistence behavior for tasks.
 type TaskRepository interface {
-	Create(ctx context.Context, t *entities.Task) error
-	Update(ctx context.Context, t *entities.Task) error
+	Create(ctx context.Context, task *entities.Task) error
+	Update(ctx context.Context, task *entities.Task) error
 	Delete(ctx context.Context, id uint, userID uint) error
 	Get(ctx context.Context, id uint, userID uint) (*entities.Task, error)
-	List(ctx context.Context, userID uint, f TaskFilter) ([]entities.Task, error)
+	List(ctx context.Context, userID uint, filter TaskFilter) ([]entities.Task, error)
 }

--- a/internal/infrastructure/repository/category.go
+++ b/internal/infrastructure/repository/category.go
@@ -16,12 +16,12 @@ func NewCategoryRepository(db *gorm.DB) interfaces.CategoryRepository {
 	return &categoryRepository{db: db}
 }
 
-func (r *categoryRepository) Create(ctx context.Context, c *entities.Category) error {
-	return r.db.WithContext(ctx).Create(c).Error
+func (r *categoryRepository) Create(ctx context.Context, category *entities.Category) error {
+	return r.db.WithContext(ctx).Create(category).Error
 }
 
-func (r *categoryRepository) Update(ctx context.Context, c *entities.Category) error {
-	return r.db.WithContext(ctx).Save(c).Error
+func (r *categoryRepository) Update(ctx context.Context, category *entities.Category) error {
+	return r.db.WithContext(ctx).Save(category).Error
 }
 
 func (r *categoryRepository) Delete(ctx context.Context, id uint, userID uint) error {
@@ -29,11 +29,11 @@ func (r *categoryRepository) Delete(ctx context.Context, id uint, userID uint) e
 }
 
 func (r *categoryRepository) Get(ctx context.Context, id uint, userID uint) (*entities.Category, error) {
-	var c entities.Category
-	if err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", id, userID).First(&c).Error; err != nil {
+	var category entities.Category
+	if err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", id, userID).First(&category).Error; err != nil {
 		return nil, err
 	}
-	return &c, nil
+	return &category, nil
 }
 
 func (r *categoryRepository) List(ctx context.Context, userID uint) ([]entities.Category, error) {

--- a/internal/infrastructure/repository/task.go
+++ b/internal/infrastructure/repository/task.go
@@ -16,12 +16,12 @@ func NewTaskRepository(db *gorm.DB) interfaces.TaskRepository {
 	return &taskRepository{db: db}
 }
 
-func (r *taskRepository) Create(ctx context.Context, t *entities.Task) error {
-	return r.db.WithContext(ctx).Create(t).Error
+func (r *taskRepository) Create(ctx context.Context, task *entities.Task) error {
+	return r.db.WithContext(ctx).Create(task).Error
 }
 
-func (r *taskRepository) Update(ctx context.Context, t *entities.Task) error {
-	return r.db.WithContext(ctx).Save(t).Error
+func (r *taskRepository) Update(ctx context.Context, task *entities.Task) error {
+	return r.db.WithContext(ctx).Save(task).Error
 }
 
 func (r *taskRepository) Delete(ctx context.Context, id uint, userID uint) error {
@@ -29,23 +29,23 @@ func (r *taskRepository) Delete(ctx context.Context, id uint, userID uint) error
 }
 
 func (r *taskRepository) Get(ctx context.Context, id uint, userID uint) (*entities.Task, error) {
-	var t entities.Task
-	if err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", id, userID).First(&t).Error; err != nil {
+	var task entities.Task
+	if err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", id, userID).First(&task).Error; err != nil {
 		return nil, err
 	}
-	return &t, nil
+	return &task, nil
 }
 
-func (r *taskRepository) List(ctx context.Context, userID uint, f interfaces.TaskFilter) ([]entities.Task, error) {
+func (r *taskRepository) List(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, error) {
 	var tasks []entities.Task
-	q := r.db.WithContext(ctx).Where("user_id = ?", userID)
-	if f.CategoryID != nil {
-		q = q.Where("category_id = ?", *f.CategoryID)
+	query := r.db.WithContext(ctx).Where("user_id = ?", userID)
+	if filter.CategoryID != nil {
+		query = query.Where("category_id = ?", *filter.CategoryID)
 	}
-	if f.State != nil {
-		q = q.Where("state = ?", *f.State)
+	if filter.State != nil {
+		query = query.Where("state = ?", *filter.State)
 	}
-	if err := q.Find(&tasks).Error; err != nil {
+	if err := query.Find(&tasks).Error; err != nil {
 		return nil, err
 	}
 	return tasks, nil

--- a/internal/infrastructure/repository/user.go
+++ b/internal/infrastructure/repository/user.go
@@ -21,9 +21,9 @@ func (r *userRepository) Create(ctx context.Context, user *entities.User) error 
 }
 
 func (r *userRepository) GetByUsername(ctx context.Context, username string) (*entities.User, error) {
-	var u entities.User
-	if err := r.db.WithContext(ctx).Where("username = ?", username).First(&u).Error; err != nil {
+	var user entities.User
+	if err := r.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
 		return nil, err
 	}
-	return &u, nil
+	return &user, nil
 }

--- a/internal/presentation/category.go
+++ b/internal/presentation/category.go
@@ -12,11 +12,11 @@ import (
 )
 
 type CategoryHandlers struct {
-	svc *useCase.CategoryService
+	categoryService *useCase.CategoryService
 }
 
-func NewCategoryHandlers(svc *useCase.CategoryService) *CategoryHandlers {
-	return &CategoryHandlers{svc: svc}
+func NewCategoryHandlers(categoryService *useCase.CategoryService) *CategoryHandlers {
+	return &CategoryHandlers{categoryService: categoryService}
 }
 
 func getUserID(c *gin.Context) uint {
@@ -42,42 +42,42 @@ func (h *CategoryHandlers) Create(c *gin.Context) {
 
 	userID := c.MustGet("userID").(uint)
 
-	cat := &entities.Category{
+	category := &entities.Category{
 		Name:        strings.TrimSpace(req.Name),
 		Description: req.Description,
 		UserID:      userID,
 	}
 
-	if err := h.svc.Create(ctx, cat); err != nil {
+	if err := h.categoryService.Create(ctx, category); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.Header("Location", "/categorias/"+strconv.FormatUint(uint64(cat.ID), 10))
-	c.JSON(http.StatusCreated, cat)
+	c.Header("Location", "/categorias/"+strconv.FormatUint(uint64(category.ID), 10))
+	c.JSON(http.StatusCreated, category)
 }
 
 func (h *CategoryHandlers) List(c *gin.Context) {
-	cats, err := h.svc.List(c.Request.Context(), getUserID(c))
+	categories, err := h.categoryService.List(c.Request.Context(), getUserID(c))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, cats)
+	c.JSON(http.StatusOK, categories)
 }
 
 func (h *CategoryHandlers) Get(c *gin.Context) {
-	id, _ := strconv.Atoi(c.Param("id"))
-	cat, err := h.svc.Get(c.Request.Context(), uint(id), getUserID(c))
+	categoryID, _ := strconv.Atoi(c.Param("id"))
+	category, err := h.categoryService.Get(c.Request.Context(), uint(categoryID), getUserID(c))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, cat)
+	c.JSON(http.StatusOK, category)
 }
 
 func (h *CategoryHandlers) Update(c *gin.Context) {
-	id, _ := strconv.Atoi(c.Param("id"))
+	categoryID, _ := strconv.Atoi(c.Param("id"))
 	var req struct {
 		Name        string `json:"nombre"`
 		Description string `json:"descripcion"`
@@ -86,17 +86,17 @@ func (h *CategoryHandlers) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	cat := &entities.Category{ID: uint(id), Name: req.Name, Description: req.Description, UserID: getUserID(c)}
-	if err := h.svc.Update(c.Request.Context(), cat); err != nil {
+	category := &entities.Category{ID: uint(categoryID), Name: req.Name, Description: req.Description, UserID: getUserID(c)}
+	if err := h.categoryService.Update(c.Request.Context(), category); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, cat)
+	c.JSON(http.StatusOK, category)
 }
 
 func (h *CategoryHandlers) Delete(c *gin.Context) {
-	id, _ := strconv.Atoi(c.Param("id"))
-	if err := h.svc.Delete(c.Request.Context(), uint(id), getUserID(c)); err != nil {
+	categoryID, _ := strconv.Atoi(c.Param("id"))
+	if err := h.categoryService.Delete(c.Request.Context(), uint(categoryID), getUserID(c)); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/presentation/router.go
+++ b/internal/presentation/router.go
@@ -12,15 +12,15 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-func NewRouter(r *gin.Engine, auth *useCase.AuthService, category *useCase.CategoryService, task *useCase.TaskService, secret string) {
-	authHandlers := NewAuthHandlers(auth)
-	categoryHandlers := NewCategoryHandlers(category)
-	taskHandlers := NewTaskHandlers(task)
+func NewRouter(router *gin.Engine, authService *useCase.AuthService, categoryService *useCase.CategoryService, taskService *useCase.TaskService, secret string) {
+	authHandlers := NewAuthHandlers(authService)
+	categoryHandlers := NewCategoryHandlers(categoryService)
+	taskHandlers := NewTaskHandlers(taskService)
 
-	r.POST("/usuarios", authHandlers.Register)
-	r.POST("/usuarios/iniciar-sesion", authHandlers.Login)
+	router.POST("/usuarios", authHandlers.Register)
+	router.POST("/usuarios/iniciar-sesion", authHandlers.Login)
 
-	authGroup := r.Group("/")
+	authGroup := router.Group("/")
 	authGroup.Use(jwtMiddleware(secret))
 	authGroup.POST("/usuarios/cerrar-sesion", authHandlers.Logout)
 


### PR DESCRIPTION
## Summary
- replace generic handler fields with descriptive names like `taskService` and `categoryService`
- clarify request parameters and variables in task and category handlers
- use explicit parameter names in services, repositories, and interfaces

## Testing
- `go vet ./internal/...`
- `go test ./internal/...`
- `go build ./internal/...`


------
https://chatgpt.com/codex/tasks/task_e_689fc897c5b08325adabc4c1c2329f99