### PR TITLE
Add service health checks to docker compose and API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,26 @@ services:
       - db-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   api:
     build: .
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgres://postgres:postgres@db:5432/todolist?sslmode=disable
       JWT_SECRET: secret
       PORT: 8080
     ports:
       - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 volumes:
   db-data:

--- a/internal/presentation/router.go
+++ b/internal/presentation/router.go
@@ -17,6 +17,10 @@ func NewRouter(router *gin.Engine, authService *useCase.AuthService, categorySer
 	categoryHandlers := NewCategoryHandlers(categoryService)
 	taskHandlers := NewTaskHandlers(taskService)
 
+	router.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
 	router.POST("/usuarios", authHandlers.Register)
 	router.POST("/usuarios/iniciar-sesion", authHandlers.Login)
 


### PR DESCRIPTION
## Summary
- add `/health` endpoint to API
- configure health checks for db and api services in docker-compose

## Testing
- `go test ./...` *(fails: command hung)*
- `go build ./...`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd1278f7c83258e6586fa30d8b09e