### PR TITLE
feat: set default avatar on user registration

### DIFF
--- a/internal/application/useCase/auth.go
+++ b/internal/application/useCase/auth.go
@@ -30,7 +30,9 @@ func (s *AuthService) Register(ctx context.Context, username, password string, p
 	if err != nil {
 		return nil, err
 	}
-	avatar := defaultAvatar
+	if profileImageURL == nil {
+		profileImageURL = &defaultAvatar
+	}
 	user := &entities.User{
 		Username:        username,
 		PasswordHash:    string(hash),


### PR DESCRIPTION
## Summary
- initialize a default profile image for newly registered users

## Testing
- `go test ./...` *(fails: c.UserID undefined, build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a14998cc6c83259b9331561b5ac9b1