### PR TITLE
feat: document categories as global

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ todolist/
 - `POST /usuarios/cerrar-sesion` - Logout
 
 #### Categorías
-- `GET /categorias` - Listar categorías del usuario
-- `POST /categorias` - Crear categoría
+- `GET /categorias` - Listar todas las categorías
+- `POST /categorias` - Crear categoría global
 - `GET /categorias/:id` - Obtener categoría
 - `PUT /categorias/:id` - Actualizar categoría
 - `DELETE /categorias/:id` - Eliminar categoría
@@ -243,7 +243,7 @@ todolist/
 
 ```sql
 users (id, username, password_hash, profile_image_url, avatar_url)
-categories (id, name, description, user_id)
+categories (id, name, description)
 tasks (id, text, created_at, due_date, state, category_id, user_id)
 ```
 
@@ -263,7 +263,6 @@ erDiagram
         int id PK
         varchar name
         text description
-        int user_id FK
     }
     
     TASKS {
@@ -276,7 +275,6 @@ erDiagram
         int user_id FK
     }
     
-    USERS ||--o{ CATEGORIES : "owns"
     USERS ||--o{ TASKS : "creates"
     CATEGORIES ||--o{ TASKS : "contains"
 ```

--- a/Task-Manager-API.postman_collection.json
+++ b/Task-Manager-API.postman_collection.json
@@ -105,7 +105,7 @@
 			"name": "Categories",
 			"item": [
 				{
-					"name": "Create Category",
+                                "name": "Create Global Category",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -135,7 +135,7 @@
 					"response": []
 				},
 				{
-					"name": "List Categories",
+                                "name": "List Global Categories",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -157,7 +157,7 @@
 					"response": []
 				},
 				{
-					"name": "Get Category by ID",
+                                "name": "Get Global Category by ID",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -180,7 +180,7 @@
 					"response": []
 				},
 				{
-					"name": "Update Category",
+                                "name": "Update Global Category",
 					"request": {
 						"method": "PUT",
 						"header": [
@@ -211,7 +211,7 @@
 					"response": []
 				},
 				{
-					"name": "Delete Category",
+                                "name": "Delete Global Category",
 					"request": {
 						"method": "DELETE",
 						"header": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,8 +3,8 @@ info:
   title: API de Tareas y Categorías (Go)
   version: "1.0.0"
   description: |
-    Backend en Go. Endpoints protegidos por JWT (bearerAuth). 
-    Las tareas y categorías son del usuario autenticado. 
+    Backend en Go. Endpoints protegidos por JWT (bearerAuth).
+    Las tareas son del usuario autenticado y las categorías son globales.
     Si el usuario no carga imagen de perfil al registrarse, se asigna avatar por defecto (lógica de servidor).
 
 servers:
@@ -102,7 +102,7 @@ paths:
   /categorias:
     get:
       tags: [ Categorías ]
-      summary: Listar categorías del usuario
+      summary: Listar todas las categorías globales
       security:
         - bearerAuth: [ ]
       responses:
@@ -117,7 +117,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
     post:
       tags: [ Categorías ]
-      summary: Crear categoría
+      summary: Crear categoría global
       security:
         - bearerAuth: [ ]
       requestBody:
@@ -144,7 +144,7 @@ paths:
   /categorias/{id}:
     get:
       tags: [ Categorías ]
-      summary: Obtener categoría por id
+      summary: Obtener categoría global por id
       security:
         - bearerAuth: [ ]
       parameters:
@@ -162,7 +162,7 @@ paths:
           $ref: '#/components/responses/NotFound'
     put:
       tags: [ Categorías ]
-      summary: Actualizar categoría
+      summary: Actualizar categoría global
       security:
         - bearerAuth: [ ]
       parameters:
@@ -191,7 +191,7 @@ paths:
           $ref: '#/components/responses/NotFound'
     delete:
       tags: [ Categorías ]
-      summary: Eliminar categoría
+      summary: Eliminar categoría global
       security:
         - bearerAuth: [ ]
       parameters:


### PR DESCRIPTION
## Summary
- remove user relationship from categories in README and ER diagram
- describe global categories in OpenAPI spec
- rename Postman requests to emphasize global categories

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a156445534832599932df461fcded9