### PR TITLE
Guardar imagen de perfil en registro

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm"
 
 	postgresrepo "todolist/internal/infrastructure/repository"
+	"todolist/internal/infrastructure/storage"
 	"todolist/internal/presentation"
 )
 
@@ -46,7 +47,8 @@ func main() {
 	taskRepo := postgresrepo.NewTaskRepository(db)
 
 	// Initialize services
-	authService := useCase.NewAuthService(userRepo, jwtSecret)
+	fileWriter := storage.NewStaticFileWriter("./static")
+	authService := useCase.NewAuthService(userRepo, fileWriter, jwtSecret)
 	categoryService := useCase.NewCategoryService(categoryRepo)
 	taskService := useCase.NewTaskService(taskRepo)
 

--- a/internal/application/useCase/auth.go
+++ b/internal/application/useCase/auth.go
@@ -3,7 +3,11 @@ package useCase
 import (
 	"context"
 	"errors"
+	"fmt"
+	"mime"
+	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"todolist/internal/domain/entities"
@@ -17,26 +21,56 @@ var defaultAvatar = "/static/default.jpg"
 
 type AuthService struct {
 	repo          interfaces.UserRepository
+	fileWriter    interfaces.FileWriter
 	jwtSecret     string
 	invalidTokens sync.Map // map[string]struct{}
 }
 
-func NewAuthService(repo interfaces.UserRepository, secret string) *AuthService {
-	return &AuthService{repo: repo, jwtSecret: secret}
+func NewAuthService(repo interfaces.UserRepository, writer interfaces.FileWriter, secret string) *AuthService {
+	return &AuthService{repo: repo, fileWriter: writer, jwtSecret: secret}
 }
 
-func (s *AuthService) Register(ctx context.Context, username, password string, profileImageURL *string) (*entities.User, error) {
+func (s *AuthService) Register(ctx context.Context, username, password string, profileImage []byte) (*entities.User, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
 	}
-	if profileImageURL == nil {
-		profileImageURL = &defaultAvatar
+
+	imagePath := defaultAvatar
+
+	if len(profileImage) > 0 {
+		const maxSize = 5 * 1024 * 1024
+		if len(profileImage) > maxSize {
+			return nil, errors.New("image too large")
+		}
+		mimeType := http.DetectContentType(profileImage)
+		if !strings.HasPrefix(mimeType, "image/") {
+			return nil, errors.New("invalid image type")
+		}
+		var ext string
+		if exts, _ := mime.ExtensionsByType(mimeType); len(exts) > 0 {
+			ext = exts[0]
+		} else {
+			switch mimeType {
+			case "image/jpeg":
+				ext = ".jpg"
+			case "image/png":
+				ext = ".png"
+			default:
+				return nil, errors.New("unsupported image type")
+			}
+		}
+		name := fmt.Sprintf("%d%s", time.Now().UnixNano(), ext)
+		if err := s.fileWriter.Write(ctx, name, profileImage); err != nil {
+			return nil, err
+		}
+		imagePath = "/static/" + name
 	}
+
 	user := &entities.User{
 		Username:        username,
 		PasswordHash:    string(hash),
-		ProfileImageURL: profileImageURL,
+		ProfileImageURL: &imagePath,
 	}
 	if err := s.repo.Create(ctx, user); err != nil {
 		return nil, err

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -378,10 +378,6 @@ components:
         password:
           type: string
           minLength: 6
-        profileImageUrl:
-          type: string
-          format: uri
-          description: Alternativa a subir archivo
     UsuarioPublico:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Validar y almacenar imagen de perfil del usuario usando FileWriter
- Adaptar handler y bootstrap para subir archivos y generar rutas
- Actualizar especificación OpenAPI del registro de usuarios

## Testing
- `go test ./...` (fails: comando se queda en ejecución y fue interrumpido)
- `go vet ./...` (fails: comando se queda en ejecución y fue interrumpido)
- `go build ./...` (fails: comando se queda en ejecución y fue interrumpido)


------
https://chatgpt.com/codex/tasks/task_e_68a15e2263f0832589abff9b5f99a936