### PR TITLE
feat: add pagination to task listing

### DIFF
--- a/Task-Manager-API.postman_collection.json
+++ b/Task-Manager-API.postman_collection.json
@@ -268,29 +268,39 @@
 					},
 					"response": []
 				},
-				{
-					"name": "List User Tasks",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt_token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/tareas/usuario",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"tareas",
-								"usuario"
-							]
-						}
-					},
-					"response": []
-				},
+                                {
+                                        "name": "List User Tasks",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "Authorization",
+                                                                "value": "Bearer {{jwt_token}}"
+                                                        }
+                                                ],
+                                                "url": {
+                                                        "raw": "{{base_url}}/tareas/usuario?page=1&pageSize=20",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "tareas",
+                                                                "usuario"
+                                                        ],
+                                                        "query": [
+                                                                {
+                                                                        "key": "page",
+                                                                        "value": "1"
+                                                                },
+                                                                {
+                                                                        "key": "pageSize",
+                                                                        "value": "20"
+                                                                }
+                                                        ]
+                                                }
+                                        },
+                                        "response": []
+                                },
 				{
 					"name": "List User Tasks with Filters",
 					"request": {

--- a/internal/application/useCase/task.go
+++ b/internal/application/useCase/task.go
@@ -45,6 +45,6 @@ func (s *TaskService) Get(ctx context.Context, id uint, userID uint) (*entities.
 	return s.repo.Get(ctx, id, userID)
 }
 
-func (s *TaskService) List(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, error) {
+func (s *TaskService) List(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, int64, error) {
 	return s.repo.List(ctx, userID, filter)
 }

--- a/internal/application/useCase/task_test.go
+++ b/internal/application/useCase/task_test.go
@@ -1,0 +1,45 @@
+package useCase
+
+import (
+	"context"
+	"testing"
+	"todolist/internal/domain/entities"
+	"todolist/internal/domain/interfaces"
+)
+
+type mockTaskRepo struct {
+	listFn func(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, int64, error)
+}
+
+func (m *mockTaskRepo) Create(ctx context.Context, task *entities.Task) error  { return nil }
+func (m *mockTaskRepo) Update(ctx context.Context, task *entities.Task) error  { return nil }
+func (m *mockTaskRepo) Delete(ctx context.Context, id uint, userID uint) error { return nil }
+func (m *mockTaskRepo) Get(ctx context.Context, id uint, userID uint) (*entities.Task, error) {
+	return nil, nil
+}
+func (m *mockTaskRepo) List(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, int64, error) {
+	if m.listFn != nil {
+		return m.listFn(ctx, userID, filter)
+	}
+	return nil, 0, nil
+}
+
+func TestTaskServiceList(t *testing.T) {
+	repo := &mockTaskRepo{
+		listFn: func(ctx context.Context, userID uint, filter interfaces.TaskFilter) ([]entities.Task, int64, error) {
+			tasks := []entities.Task{{ID: 1}, {ID: 2}}
+			return tasks, 2, nil
+		},
+	}
+	svc := NewTaskService(repo)
+	items, total, err := svc.List(context.Background(), 1, interfaces.TaskFilter{Page: 1, PageSize: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
+	}
+}

--- a/internal/domain/interfaces/task_repository.go
+++ b/internal/domain/interfaces/task_repository.go
@@ -8,6 +8,8 @@ import (
 type TaskFilter struct {
 	CategoryID *uint
 	State      *string
+	Page       int
+	PageSize   int
 }
 
 // TaskRepository defines the persistence behavior for tasks.
@@ -16,5 +18,5 @@ type TaskRepository interface {
 	Update(ctx context.Context, task *entities.Task) error
 	Delete(ctx context.Context, id uint, userID uint) error
 	Get(ctx context.Context, id uint, userID uint) (*entities.Task, error)
-	List(ctx context.Context, userID uint, filter TaskFilter) ([]entities.Task, error)
+	List(ctx context.Context, userID uint, filter TaskFilter) ([]entities.Task, int64, error)
 }


### PR DESCRIPTION
## Summary
- add page and pageSize filters for task queries
- include total count in task listing service and repository
- paginate tasks in HTTP handler and update Postman collection

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a165ec1c78832580fef0a0bcd792b4