### PR TITLE
docs: document 500 error responses

### DIFF
--- a/Task-Manager-API.postman_collection.json
+++ b/Task-Manager-API.postman_collection.json
@@ -134,28 +134,60 @@
 					},
 					"response": []
 				},
-				{
+                                {
                                 "name": "List Global Categories",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt_token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/categorias",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"categorias"
-							]
-						}
-					},
-					"response": []
-				},
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "Authorization",
+                                                                "value": "Bearer {{jwt_token}}"
+                                                        }
+                                                ],
+                                                "url": {
+                                                        "raw": "{{base_url}}/categorias",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "categorias"
+                                                        ]
+                                                }
+                                        },
+                                        "response": [
+                                                {
+                                                        "name": "Internal Server Error",
+                                                        "originalRequest": {
+                                                                "method": "GET",
+                                                                "header": [
+                                                                        {
+                                                                                "key": "Authorization",
+                                                                                "value": "Bearer {{jwt_token}}"
+                                                                        }
+                                                                ],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/categorias",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "categorias"
+                                                                        ]
+                                                                }
+                                                        },
+                                                        "status": "Internal Server Error",
+                                                        "code": 500,
+                                                        "_postman_previewlanguage": "json",
+                                                        "header": [
+                                                                {
+                                                                        "key": "Content-Type",
+                                                                        "value": "application/json"
+                                                                }
+                                                        ],
+                                                        "body": "{\n  \"code\": \"internal_error\",\n  \"message\": \"Error interno\"\n}"
+                                                }
+                                        ]
+                                },
 				{
                                 "name": "Get Global Category by ID",
 					"request": {
@@ -299,49 +331,143 @@
                                                         ]
                                                 }
                                         },
-                                        "response": []
+                                        "response": [
+                                                {
+                                                        "name": "Internal Server Error",
+                                                        "originalRequest": {
+                                                                "method": "GET",
+                                                                "header": [
+                                                                        {
+                                                                                "key": "Authorization",
+                                                                                "value": "Bearer {{jwt_token}}"
+                                                                        }
+                                                                ],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/tareas/usuario?page=1&pageSize=20",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "tareas",
+                                                                                "usuario"
+                                                                        ],
+                                                                        "query": [
+                                                                                {
+                                                                                        "key": "page",
+                                                                                        "value": "1"
+                                                                                },
+                                                                                {
+                                                                                        "key": "pageSize",
+                                                                                        "value": "20"
+                                                                                }
+                                                                        ]
+                                                                }
+                                                        },
+                                                        "status": "Internal Server Error",
+                                                        "code": 500,
+                                                        "_postman_previewlanguage": "json",
+                                                        "header": [
+                                                                {
+                                                                        "key": "Content-Type",
+                                                                        "value": "application/json"
+                                                                }
+                                                        ],
+                                                        "body": "{\n  \"code\": \"internal_error\",\n  \"message\": \"Error interno\"\n}"
+                                                }
+                                        ]
                                 },
-				{
-					"name": "List User Tasks with Filters",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt_token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/tareas/usuario?categoriaId={{category_id}}&estado=Sin Empezar&page=1&pageSize=10",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"tareas",
-								"usuario"
-							],
-							"query": [
-								{
-									"key": "categoriaId",
-									"value": "{{category_id}}"
-								},
-								{
-									"key": "estado",
-									"value": "Sin Empezar"
-								},
-								{
-									"key": "page",
-									"value": "1"
-								},
-								{
-									"key": "pageSize",
-									"value": "10"
-								}
-							]
-						}
-					},
-					"response": []
-				},
+                                {
+                                        "name": "List User Tasks with Filters",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "Authorization",
+                                                                "value": "Bearer {{jwt_token}}"
+                                                        }
+                                                ],
+                                                "url": {
+                                                        "raw": "{{base_url}}/tareas/usuario?categoriaId={{category_id}}&estado=Sin Empezar&page=1&pageSize=10",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "tareas",
+                                                                "usuario"
+                                                        ],
+                                                        "query": [
+                                                                {
+                                                                        "key": "categoriaId",
+                                                                        "value": "{{category_id}}"
+                                                                },
+                                                                {
+                                                                        "key": "estado",
+                                                                        "value": "Sin Empezar"
+                                                                },
+                                                                {
+                                                                        "key": "page",
+                                                                        "value": "1"
+                                                                },
+                                                                {
+                                                                        "key": "pageSize",
+                                                                        "value": "10"
+                                                                }
+                                                        ]
+                                                }
+                                        },
+                                        "response": [
+                                                {
+                                                        "name": "Internal Server Error",
+                                                        "originalRequest": {
+                                                                "method": "GET",
+                                                                "header": [
+                                                                        {
+                                                                                "key": "Authorization",
+                                                                                "value": "Bearer {{jwt_token}}"
+                                                                        }
+                                                                ],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/tareas/usuario?categoriaId={{category_id}}&estado=Sin Empezar&page=1&pageSize=10",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "tareas",
+                                                                                "usuario"
+                                                                        ],
+                                                                        "query": [
+                                                                                {
+                                                                                        "key": "categoriaId",
+                                                                                        "value": "{{category_id}}"
+                                                                                },
+                                                                                {
+                                                                                        "key": "estado",
+                                                                                        "value": "Sin Empezar"
+                                                                                },
+                                                                                {
+                                                                                        "key": "page",
+                                                                                        "value": "1"
+                                                                                },
+                                                                                {
+                                                                                        "key": "pageSize",
+                                                                                        "value": "10"
+                                                                                }
+                                                                        ]
+                                                                }
+                                                        },
+                                                        "status": "Internal Server Error",
+                                                        "code": 500,
+                                                        "_postman_previewlanguage": "json",
+                                                        "header": [
+                                                                {
+                                                                        "key": "Content-Type",
+                                                                        "value": "application/json"
+                                                                }
+                                                        ],
+                                                        "body": "{\n  \"code\": \"internal_error\",\n  \"message\": \"Error interno\"\n}"
+                                                }
+                                        ]
+                                },
 				{
 					"name": "Get Task by ID",
 					"request": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,8 @@ paths:
                   status:
                     type: string
                     example: ok
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /usuarios:
     post:
       tags: [ Usuarios ]
@@ -77,6 +79,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /usuarios/iniciar-sesion:
     post:
       tags: [ Autenticación ]
@@ -104,6 +108,8 @@ paths:
                     description: JWT Bearer
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /usuarios/cerrar-sesion:
     post:
       tags: [ Autenticación ]
@@ -115,6 +121,8 @@ paths:
           description: Sesión cerrada (token invalidado/rotado)
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /categorias:
     get:
@@ -132,6 +140,8 @@ paths:
                 items: { $ref: '#/components/schemas/Categoria' }
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [ Categorías ]
       summary: Crear categoría global
@@ -158,6 +168,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /categorias/{id}:
     get:
       tags: [ Categorías ]
@@ -177,6 +189,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [ Categorías ]
       summary: Actualizar categoría global
@@ -206,6 +220,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [ Categorías ]
       summary: Eliminar categoría global
@@ -220,6 +236,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /tareas:
     post:
@@ -244,6 +262,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /tareas/usuario:
     get:
@@ -288,6 +308,8 @@ paths:
                     type: integer
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /tareas/{id}:
     get:
@@ -308,6 +330,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [ Tareas ]
       summary: Actualizar tarea
@@ -334,6 +358,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [ Tareas ]
       summary: Eliminar tarea
@@ -348,6 +374,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
 components:
   securitySchemes:
@@ -378,6 +406,12 @@ components:
             $ref: '#/components/schemas/Error'
     NotFound:
       description: Recurso no encontrado
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: Error interno
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary
- document 500 Internal Server Error responses across API paths
- add InternalServerError component in OpenAPI spec
- include 500 error examples for list categories and user tasks in Postman collection

## Testing
- `python -c 'import yaml,sys; yaml.safe_load(open("openapi.yaml"))'`
- `jq . Task-Manager-API.postman_collection.json >/dev/null`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a16c8d1e2883258a5600679dc82a13